### PR TITLE
Add a Plone buildout to the package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+.Python
+.coverage
+*.egg-info
+*.log
+*.mo
+*.py?
+*.swp
+# dirs
+bin/
+buildout-cache/
+develop-eggs/
+eggs/
+htmlcov/
+include/
+lib/
+local/
+parts/
+src/*
+test.plone_addon/
+var/
+# files
+.installed.cfg
+.mr.developer.cfg
+lib64
+log.html
+output.xml
+pip-selfcheck.json
+report.html
+.vscode/
+node_modules/
+# excludes
+!.coveragerc
+!.editorconfig
+!.gitattributes
+!.gitignore
+!.gitkeep
+!.travis.yml
+!src/collective

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ node_modules/
 !.gitignore
 !.gitkeep
 !.travis.yml
-!src/collective

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# we want to exit on errors
+set -e
+
+VIRTUALENV_BIN=$(command -v virtualenv-2.7 || command -v virtualenv)
+PYTHON=$(command -v python2.7 || command -v python)
+"$VIRTUALENV_BIN" -p "$PYTHON" .
+
+# Let's enter the virtualenv
+. bin/activate
+./bin/pip install -r requirements.txt
+
+# Now we have
+PYTHON=$(command -v python2.7 || command -v python)
+./bin/buildout

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,0 +1,44 @@
+[buildout]
+extends = http://dist.plone.org/release/5.1/versions.cfg
+show-picked-versions = true
+extensions =
+    mr.developer
+
+parts =
+    instance
+    omelette
+develop = .
+
+auto-checkout =
+    mockup
+
+
+[instance]
+recipe = plone.recipe.zope2instance
+user = admin:admin
+http-address = 8080
+eggs =
+    Plone
+    Pillow
+    collective.jstraining
+
+
+[omelette]
+recipe = collective.recipe.omelette
+eggs = ${instance:eggs}
+
+
+[versions]
+# Don't use a released version of collective.jstraining
+collective.jstraining =
+# development dependencies (tools and pre commit hook)
+setuptools =
+zc.buildout =
+plone.api = >=1.8.4
+mr.developer = >=1.38
+z3c.jbot = 0.7.2
+zc.recipe.egg = 2.0.3
+
+[sources]
+mockup = git https://github.com/plone/mockup.git pushurl=git@github.com:plone/mockup.git
+

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -11,7 +11,7 @@ parts =
 develop = .
 
 auto-checkout =
-    mockup
+#    mockup
 
 
 [instance]

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = http://dist.plone.org/release/5.1/versions.cfg
+extends = http://dist.plone.org/release/5.1.4/versions.cfg
 show-picked-versions = true
 extensions =
     mr.developer

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -7,6 +7,7 @@ extensions =
 parts =
     instance
     omelette
+    zopepy
 develop = .
 
 auto-checkout =
@@ -28,6 +29,18 @@ recipe = collective.recipe.omelette
 eggs = ${instance:eggs}
 
 
+[zopepy]
+recipe = zc.recipe.egg
+eggs =
+    ${instance:eggs}
+# need to explicitly mention Products.CMFPlone in order for plone-compile-resources to be found
+    Products.CMFPlone
+interpreter = zopepy
+scripts =
+    zopepy
+    plone-compile-resources
+
+
 [versions]
 # Don't use a released version of collective.jstraining
 collective.jstraining =
@@ -38,6 +51,7 @@ plone.api = >=1.8.4
 mr.developer = >=1.38
 z3c.jbot = 0.7.2
 zc.recipe.egg = 2.0.3
+
 
 [sources]
 mockup = git https://github.com/plone/mockup.git pushurl=git@github.com:plone/mockup.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+setuptools==38.7.0
+zc.buildout==2.11.4


### PR DESCRIPTION
The javascript configuration in the [training_buildout](https://github.com/collective/training_buildout/blob/plone5/buildout.cfg) has been removed and I think it's ok, but now the js training needs a proper buildout with this collective.jstraining package available.
I think that adding a simple buildout to this repo will make it easy for others to setup their own environment for the training.

I will update the training docs asap to use this addition instead of `training_buildout`